### PR TITLE
Add RUN label to be able to use the image as cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ WORKDIR /project
 LABEL INFO something seems to have changed about atomic (http://github.com/projectatomic/atomic), so the RUN LABEL is just for user reference
 LABEL USER_BUILD docker build -t da .
 LABEL USER_RUN docker run -it --rm --privileged -v `pwd`:/project --name da -e NAME=devassistant -e IMAGE=da da
-#LABEL RUN docker run -it --rm --privileged -v `pwd`:/project --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
+LABEL RUN docker run -d --privileged -v `pwd`:/project --name NAME -e NAME=NAME -e IMAGE=IMAGE --entrypoint=bash IMAGE -c \"tail -f /dev/null\"
 
 ENTRYPOINT ["/usr/bin/da"]


### PR DESCRIPTION
This change let's you do this:

```
atomic run da
alias da="atomic run da da"
da create nulecule -n Foo
```

To describe the mechanism behind it -  `atomic` calls a `_start` method if the container already exists, but is not running. But we need it to call `_running` method - and for that container needs to be up...so, let's do something stupid to keep it alive and then it's easy...

It's kinda ugly hack, but it works:) Would it be ok for now?
