### PR TITLE
changes to allow for user integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
 FROM fedora:rawhide
 
 RUN yum clean all && yum -y update && yum -y install devassistant-cli python3-jsonschema && yum clean all
+RUN useradd dev
 
+VOLUME /home/dev
+VOLUME /project
+RUN chown dev:dev -R /project
+WORKDIR /project
 RUN da pkg install nulecule
 
-VOLUME /project
-WORKDIR /project
+USER dev
 
-LABEL INFO something seems to have changed about atomic (http://github.com/projectatomic/atomic), so the RUN LABEL is just for user reference
-LABEL USER_BUILD docker build -t da .
-LABEL USER_RUN docker run -it --rm --privileged -v `pwd`:/project --name da -e NAME=devassistant -e IMAGE=da da
-#LABEL RUN docker run -it --rm --privileged -v `pwd`:/project --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
+LABEL RUN docker run -d --privileged  -u `id -u $USER` -v `echo $HOME`:/home/dev -v `pwd`:/project --name NAME -e NAME=NAME -e IMAGE=IMAGE --entrypoint=bash IMAGE -c \"tail -f /dev/null\"
+
+LABEL USER_RUN docker run -it --rm --privileged --name da -u `id -u $USER` -v `echo $HOME`:/home/dev -v `pwd`:/project IMAGE
 
 ENTRYPOINT ["/usr/bin/da"]


### PR DESCRIPTION
atomic run still doesn't like our run label; updated the image to allow for including user info like .gitconfig; would like to include someplace to install daps which I think will fail right now
