### PR TITLE
Adapted Dockerfile for CentOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,21 @@
-FROM fedora:rawhide
+FROM centos:7
 
-RUN yum clean all && yum -y update && yum -y install devassistant-cli python3-jsonschema && yum clean all
+RUN yum clean all && yum -y install wget && yum clean all
+RUN wget https://www.softwarecollections.org/en/scls/rhscl/python33/epel-7-x86_64/download/rhscl-python33-epel-7-x86_64.noarch.rpm
+RUN yum clean all && yum -y localinstall rhscl-python33-epel-7-x86_64.noarch.rpm && yum -y update && yum -y install python33 scl-utils && yum clean all
+RUN scl enable python33 "easy_install pip"
+RUN scl enable python33 "pip3 install devassistant"
+
+RUN echo '#!/bin/sh' > /usr/local/bin/da
+RUN echo 'scl enable python33 "da $*"' >> /usr/local/bin/da
+RUN chmod +x /usr/local/bin/da
+RUN scl enable python33 "da pkg install nulecule"
+
 RUN useradd dev
-
 VOLUME /home/dev
 VOLUME /project
 RUN chown dev:dev -R /project
 WORKDIR /project
-RUN da pkg install nulecule
 
 USER dev
 
@@ -15,4 +23,4 @@ LABEL RUN docker run -d --privileged  -u `id -u $USER` -v `echo $HOME`:/home/dev
 
 LABEL USER_RUN docker run -it --rm --privileged --name da -u `id -u $USER` -v `echo $HOME`:/home/dev -v `pwd`:/project IMAGE
 
-ENTRYPOINT ["/usr/bin/da"]
+ENTRYPOINT ["/usr/local/bin/da"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM centos:7
 
-RUN yum clean all && yum -y install wget && yum clean all
-RUN wget https://www.softwarecollections.org/en/scls/rhscl/python33/epel-7-x86_64/download/rhscl-python33-epel-7-x86_64.noarch.rpm
-RUN yum clean all && yum -y localinstall rhscl-python33-epel-7-x86_64.noarch.rpm && yum -y update && yum -y install python33 scl-utils && yum clean all
-RUN scl enable python33 "easy_install pip"
-RUN scl enable python33 "pip3 install devassistant"
+RUN yum -y install https://www.softwarecollections.org/en/scls/rhscl/rh-python34/epel-7-x86_64/download/rhscl-rh-python34-epel-7-x86_64.noarch.rpm && \
+    yum clean all
+RUN yum -y update && yum -y install rh-python34 scl-utils && yum clean all
+RUN scl enable rh-python34 "easy_install pip"
+RUN scl enable rh-python34 "pip3 install devassistant"
 
-RUN echo '#!/bin/sh' > /usr/local/bin/da
-RUN echo 'scl enable python33 "da $*"' >> /usr/local/bin/da
-RUN chmod +x /usr/local/bin/da
-RUN scl enable python33 "da pkg install nulecule"
+RUN echo '#!/bin/sh' > /usr/local/bin/da-scl
+RUN echo 'scl enable rh-python34 "da $*"' >> /usr/local/bin/da-scl
+RUN chmod +x /usr/local/bin/da-scl
+RUN scl enable rh-python34 "da pkg install nulecule"
 
 RUN useradd dev
 VOLUME /home/dev
@@ -23,4 +23,4 @@ LABEL RUN docker run -d --privileged  -u `id -u $USER` -v `echo $HOME`:/home/dev
 
 LABEL USER_RUN docker run -it --rm --privileged --name da -u `id -u $USER` -v `echo $HOME`:/home/dev -v `pwd`:/project IMAGE
 
-ENTRYPOINT ["/usr/local/bin/da"]
+ENTRYPOINT ["/usr/local/bin/da-scl"]


### PR DESCRIPTION
Using the upstream community `python33` software collection and
DevAssistant from the PyPI, the image now uses the stable CentOS
as its basis.

Entry point is now `/usr/local/bin/da`, which is a wrapper script
that launches da in the `python33` SCL.
